### PR TITLE
Disabling relay does not clean up BITs

### DIFF
--- a/dds/DCPS/PeriodicTask.h
+++ b/dds/DCPS/PeriodicTask.h
@@ -19,7 +19,8 @@ namespace DCPS {
 class PeriodicTask : public RcEventHandler {
 public:
   explicit PeriodicTask(RcHandle<ReactorInterceptor> interceptor)
-    : interceptor_(interceptor)
+    : user_enabled_(false)
+    , interceptor_(interceptor)
     , enabled_(false)
   {
     reactor(interceptor->reactor());

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -4212,14 +4212,14 @@ ParticipantData_t& Spdp::get_participant_data(const DCPS::RepoId& guid)
 }
 
 void
-Spdp::rtps_relay_only_now(bool f)
+Spdp::rtps_relay_only_now(bool flag)
 {
-  ACE_UNUSED_ARG(f);
+  ACE_UNUSED_ARG(flag);
 
 #ifdef OPENDDS_SECURITY
-  sedp_->rtps_relay_only_now(f);
+  sedp_->rtps_relay_only_now(flag);
 
-  if (f) {
+  if (flag) {
     ACE_GUARD(ACE_Thread_Mutex, g, lock_);
 
     tport_->relay_sender_->enable(false, config_->spdp_rtps_relay_send_period());

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -4217,14 +4217,14 @@ Spdp::use_rtps_relay_now(bool f)
 }
 
 void
-Spdp::use_ice_now(bool f)
+Spdp::use_ice_now(bool flag)
 {
-  ACE_UNUSED_ARG(f);
+  ACE_UNUSED_ARG(flag);
 
 #ifdef OPENDDS_SECURITY
-  sedp_->use_ice_now(f);
+  sedp_->use_ice_now(flag);
 
-  if (f) {
+  if (flag) {
     ICE::Endpoint* spdp_endpoint = tport_->get_ice_endpoint();
     ICE::Endpoint* sedp_endpoint = sedp_->get_ice_endpoint();
 

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -355,6 +355,7 @@ private:
     DCPS::RcHandle<SpdpPeriodic> relay_stun_task_;
     ICE::ServerReflexiveStateMachine relay_srsm_;
     void process_relay_sra(ICE::ServerReflexiveStateMachine::StateChange);
+    void disable_relay_stun_task();
 #endif
     bool network_is_unreachable_;
     bool ice_endpoint_added_;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1869,7 +1869,7 @@ RtpsUdpDataLink::RtpsReader::process_heartbeat_i(const RTPS::HeartBeatSubmessage
       gather_preassociation_acknack_i(meta_submessages, writer);
     }
   } else {
-    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: RtpsUdpDataLink::RtpsReader::process_heartbeat_i - %C -> %C invalid heartbeat\n", LogGuid(writer->id_).c_str(), LogGuid(id_).c_str()));
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: RtpsUdpDataLink::RtpsReader::process_heartbeat_i - %C -> %C invalid heartbeat first=%q last=%q count=%d\n", LogGuid(writer->id_).c_str(), LogGuid(id_).c_str(), hb_first.getValue(), hb_last.getValue(), heartbeat.count.value));
   }
 
   guard.release();

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
@@ -41,6 +41,7 @@ public:
 #ifdef OPENDDS_SECURITY
   ICE::ServerReflexiveStateMachine& relay_srsm() { return relay_srsm_; }
   void process_relay_sra(ICE::ServerReflexiveStateMachine::StateChange);
+  void disable_relay_stun_task();
 #endif
 
   virtual void update_locators(const RepoId& /*remote*/,


### PR DESCRIPTION
Problem
-------

The `use_rtps_relay` method in Spdp interpretted the flag
incorrectly, i.e., disabled when the flag was true but attempted to
clean the ParticipantLocation topic.

Calling `use_rtps_relay(false)` in both Spdp and the RTPS transport
does nothing to cleanup the ConnectionRecords that the relay stun task generates.

Solution
--------

Fix the logical errors in `use_rtps_relay` and clean up the
ConnectionRecords when disabling the relay.